### PR TITLE
Predict from SKL object

### DIFF
--- a/mlqm/core.py
+++ b/mlqm/core.py
@@ -589,16 +589,28 @@ class Dataset(object):
             raise RuntimeError("Cannot train using {} yet.".format(traintype))
         # }}}
 
-    def predict(self, X, Xt=None):
+    def predict(self, X=None):
 # {{{
         '''
-        Automatically predict using saved ds model
-        Currently defaults to using skl object
-        Must add other capability!
+        Automatically predict using skl object in Dataset
+
+        Parameters:
+        X (optional): ndarray, shape (M,N) w/ M = #points and N = #features
+
+        Returns:
+        self.skl.predict(X): ndarray, shape (M,) w/ M = #points
         '''
+        if not X: # no test set passed
+            if 'trainers' in self.data and self.data['trainers']: # remove training set
+                X = np.delete(self.grand["representations"],self.data['trainers'],axis=0)
+            else:
+                X = self.grand["representations"] # use entire grand set for testing
+        else:
+            print("Predicting {}-point test set...".format(X.shape))
+
         # Case 1: no skl object available
         try:
-            skl = self.skl
+            self.skl
         except AttributeError:
             raise Exception('No Scikit-Learn object available! Please run DataSet.train().')
 

--- a/mlqm/core.py
+++ b/mlqm/core.py
@@ -569,10 +569,13 @@ class Dataset(object):
                 print("Loading coefficients from Dataset.")
                 alpha = np.asarray(self.data['a'])
                 krr.dual_coef_ = alpha
+                krr.X_fit_ = t_REPS
             else:
                 print("Model training using s = {} and l = {} . . .".format(self.data['s'],self.data['l']))
                 krr.fit(t_REPS,t_VALS)
                 self.data['a'] = list(krr.dual_coef_)
+            self.skl = krr
+            print("Scikit-Learn model available.")
             return self, t_AVG
             # }}}
 
@@ -585,3 +588,21 @@ class Dataset(object):
         else:
             raise RuntimeError("Cannot train using {} yet.".format(traintype))
         # }}}
+
+    def predict(self, X, Xt=None):
+# {{{
+        '''
+        Automatically predict using saved ds model
+        Currently defaults to using skl object
+        Must add other capability!
+        '''
+        # Case 1: no skl object available
+        try:
+            skl = self.skl
+        except AttributeError:
+            raise Exception('No Scikit-Learn object available! Please run DataSet.train().')
+
+        # Case 2: a fully-prepared skl object is available
+        return self.skl.predict(X)
+# }}}
+

--- a/tests/test_krr.py
+++ b/tests/test_krr.py
@@ -37,7 +37,7 @@ def test_krr_wrap():
     ds.setup = setup
     ds.data = data
     ds,t_AVG = ds.train("KRR")
-    a_pred = ds.predict(v_reps)
+    a_pred = ds.predict()
     a_pred = np.add(a_pred,t_AVG)
 
     # SKL 

--- a/tests/test_krr.py
+++ b/tests/test_krr.py
@@ -37,7 +37,7 @@ def test_krr_wrap():
     ds.setup = setup
     ds.data = data
     ds,t_AVG = ds.train("KRR")
-    a_pred = mlqm.krr.predict(ds,v_reps)
+    a_pred = ds.predict(v_reps)
     a_pred = np.add(a_pred,t_AVG)
 
     # SKL 


### PR DESCRIPTION
In an effort to move towards fully relying on `Scikit-Learn` for pure ML (see #2 ), a `Dataset.predict()` function has been added. This function (mostly) grabs a `scikit-learn` model object, stored in the `Dataset` at training time, and calls `predict` on it. 

Necessary for this are the following changes:
- [x] Add `skl` object to `Dataset`
- [x] Ensure `skl` gets set properly, even from imported serialized (e.g. JSON) `Dataset`s 
- [x] Error handling:
- - [x] No `skl` object
- - [x] Unfinished `skl` object (e.g. no `skl.X_fit_`)
- - [x] Update test
- [x] Optionally pull test set from `Dataset.grand`.

In the future, this may need to be made more transparent, perhaps through directly storing the `skl` model (see their [Model Persistence](https://scikit-learn.org/stable/modules/model_persistence.html) documentation) and completely eliminating the option to use the "home-made" `KRR` and `k-means` methods.

Unfinished `skl` models are usually caught at `predict` time by the `NotFittedError`, and `Dataset.train` should take care of setting `skl.X_fit_` and `skl.dual_coef_` whether or not the model is trained or populated through serialized `Dataset`. 