### PR TITLE
Reduce default KRR hyper grid

### DIFF
--- a/mlqm/core.py
+++ b/mlqm/core.py
@@ -517,11 +517,8 @@ class Dataset(object):
         if 'loss' in kwargs:
             loss = kwargs['loss']
         else:
-            loss = 'neg_mean_squared_error' # erratic for LiF
-#            loss = 'neg_mean_absolute_error' # erratic
-#            loss = 'explained_variance' # smooth but wrong for LiF
-#            loss = 'neg_median_absolute_error' # erratic
             # skl default is 'r2' but it's terrible
+            loss = 'neg_mean_squared_error'
         if 'kernel' in kwargs:
             kernel = kwargs['kernel']
         else:
@@ -530,7 +527,6 @@ class Dataset(object):
         if traintype.lower() in ["krr","kernel_ridge"]:
             # {{{
             print("Training via the {} algorithm . . .".format(traintype))
-#            ds, t_AVG = krr.train(self, **kwargs) 
             from sklearn.kernel_ridge import KernelRidge
             from sklearn.model_selection import GridSearchCV
 
@@ -554,8 +550,12 @@ class Dataset(object):
                     k = kwargs['k']
                 else:
                     k = self.setup['M']
-                parameters = {'alpha':np.logspace(-12,12,num=12),
-                              'gamma':np.logspace(-12,12,num=12)}
+                if 'gridp' in kwargs:
+                    gridp = kwargs['gridp']
+                else:
+                    gridp = 12
+                parameters = {'alpha':np.logspace(-12,12,num=gridp),
+                              'gamma':np.logspace(-12,12,num=gridp)}
                 krr_regressor = GridSearchCV(krr,parameters,scoring=loss,cv=k)
                 krr_regressor.fit(t_REPS,t_VALS)
                 self.data['hypers'] = True

--- a/mlqm/core.py
+++ b/mlqm/core.py
@@ -554,8 +554,8 @@ class Dataset(object):
                     k = kwargs['k']
                 else:
                     k = self.setup['M']
-                parameters = {'alpha':np.logspace(-12,12,num=50),
-                              'gamma':np.logspace(-12,12,num=50)}
+                parameters = {'alpha':np.logspace(-12,12,num=12),
+                              'gamma':np.logspace(-12,12,num=12)}
                 krr_regressor = GridSearchCV(krr,parameters,scoring=loss,cv=k)
                 krr_regressor.fit(t_REPS,t_VALS)
                 self.data['hypers'] = True

--- a/tests/test_krr.py
+++ b/tests/test_krr.py
@@ -36,7 +36,7 @@ def test_krr_wrap():
     ds = mlqm.Dataset(reps = reps, vals = mp2_E)
     ds.setup = setup
     ds.data = data
-    ds,t_AVG = ds.train("KRR")
+    ds,t_AVG = ds.train("KRR",gridp=12)
     a_pred = ds.predict()
     a_pred = np.add(a_pred,t_AVG)
 

--- a/tests/test_krr.py
+++ b/tests/test_krr.py
@@ -18,7 +18,7 @@ def test_krr_wrap():
     # MLQM (default):
     ## rbf kernel
     ## k-fold CV (k = M)
-    ## alpha/gamma hypers opt on np.logspace(-12,12,num=50)
+    ## alpha/gamma hypers opt on np.logspace(-12,12,num=12)
     ## neg_mean_squared_error loss
     ## training targets automatically shifted by average
     setup = {
@@ -44,8 +44,8 @@ def test_krr_wrap():
     ## use MLQM defaults, manually shift training targets
     krr = KernelRidge(kernel='rbf')
     avg = np.mean(t_mp2_E)
-    parameters = {'alpha':np.logspace(-12,12,num=50),
-                  'gamma':np.logspace(-12,12,num=50)}
+    parameters = {'alpha':np.logspace(-12,12,num=12),
+                  'gamma':np.logspace(-12,12,num=12)}
     krr_regressor = GridSearchCV(krr,parameters,scoring='neg_mean_squared_error',cv=len(t_mp2_E))
     krr_regressor.fit(t_reps,t_mp2_E-avg)
     krr = krr_regressor.best_estimator_


### PR DESCRIPTION
The default hyperparameters for KRR (alpha and gamma, in `skl` terms) are currently optimized on a 50-point grid. This has been reduced to 12 to drastically reduce training time, as tests show minimal effect on the quality of results. 

Optional kwarg `gridp` can be passed into `train` to override default grid size for tighter optimization. 